### PR TITLE
Gives error if Link is not type ticket

### DIFF
--- a/html/Callbacks/LinkedTicketsHistory/Ticket/Display.html/AfterShowHistory
+++ b/html/Callbacks/LinkedTicketsHistory/Ticket/Display.html/AfterShowHistory
@@ -8,11 +8,11 @@
 <%INIT>
 my @tickets;
 my @link_types = grep { defined } RT->Config->Get('LinkedTicketsHistoryTypes');
-@link_types = qw/MemberOf Members RefersTo ReferredToBy DependsOn DependedOnBy/ unless @link_types;
+@link_types = qw/MemberOf Members DependsOn DependedOnBy/ unless @link_types;
 for my $type ( @link_types ) {
     my $links = $Ticket->$type;
     while ( my $link = $links->Next ) {
-        my $ticket = $type =~ /MemberOf|RefersTo|DependsOn/ ? $link->TargetObj : $link->BaseObj;
+        my $ticket = $type =~ /MemberOf|DependsOn/ ? $link->TargetObj : $link->BaseObj;
         next unless $ticket->isa('RT::Ticket'); # link could be an article
         push @tickets, $ticket if $ticket->CurrentUserHasRight('ShowTicket');
     }


### PR DESCRIPTION
Removed: RefersTo ReferredToByRefersTo to get it running, should check if link is type ticket.
